### PR TITLE
Add link to MCP observability guide

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -62,7 +62,8 @@ export default defineConfig({
             { label: 'Handling CORS Issues', slug: 'docs/guides/handling-cors' },
             { label: 'Mocking API Responses', slug: 'docs/guides/mocking' },
             { label: 'Using Response Overrides', slug: 'docs/guides/response-override' },
-            { label: 'Capturing Webhooks', slug: 'docs/guides/webhook-debugging' }
+            { label: 'Capturing Webhooks', slug: 'docs/guides/webhook-debugging' },
+            { label: 'Observability for MCP Agents', slug: 'docs/guides/mcp-observability' }
           ]
         },
         {


### PR DESCRIPTION
## Summary
- add `Observability for MCP Agents` entry to Guides sidebar

## Testing
- `npm test` *(fails: Missing script "test"; no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b222cb899c8321b6090283ff8be2b2